### PR TITLE
PostgreSQL Partitioned Tables support

### DIFF
--- a/internal/loader.go
+++ b/internal/loader.go
@@ -283,7 +283,7 @@ func (tl TypeLoader) LoadSchema(args *ArgType) error {
 		return err
 	}
 
-	// merge views with the tableMap and/or partitionMap
+	// merge views with the tableMap and/or partitionedTablesMap
 	for k, v := range viewMap {
 		if tableMap != nil {
 			tableMap[k] = v

--- a/internal/types.go
+++ b/internal/types.go
@@ -55,7 +55,7 @@ const (
 	// View reltype
 	View
 
-	//Partition reltype
+	//Partitioned table reltype
 	PartitionedTable
 )
 

--- a/internal/types.go
+++ b/internal/types.go
@@ -56,7 +56,7 @@ const (
 	View
 
 	//Partition reltype
-	Partition
+	PartitionedTable
 )
 
 // EscType represents the different escape types.
@@ -76,8 +76,8 @@ func (rt RelType) String() string {
 		s = "TABLE"
 	case View:
 		s = "VIEW"
-	case Partition:
-		s = "PARTITION"
+	case PartitionedTable:
+		s = "PARTITIONED_TABLE"
 	default:
 		panic("unknown RelType")
 	}

--- a/internal/types.go
+++ b/internal/types.go
@@ -54,6 +54,9 @@ const (
 
 	// View reltype
 	View
+
+	//Partition reltype
+	Partition
 )
 
 // EscType represents the different escape types.
@@ -73,6 +76,8 @@ func (rt RelType) String() string {
 		s = "TABLE"
 	case View:
 		s = "VIEW"
+	case Partition:
+		s = "PARTITION"
 	default:
 		panic("unknown RelType")
 	}

--- a/loaders/postgres.go
+++ b/loaders/postgres.go
@@ -43,6 +43,8 @@ func PgRelkind(relType internal.RelType) string {
 		s = "r"
 	case internal.View:
 		s = "v"
+	case internal.Partition:
+		s = "p"
 	default:
 		panic("unsupported RelType")
 	}

--- a/loaders/postgres.go
+++ b/loaders/postgres.go
@@ -43,7 +43,7 @@ func PgRelkind(relType internal.RelType) string {
 		s = "r"
 	case internal.View:
 		s = "v"
-	case internal.Partition:
+	case internal.PartitionedTable:
 		s = "p"
 	default:
 		panic("unsupported RelType")


### PR DESCRIPTION
Added support for Postgres DB code generation, while it has partitioned tables.

Assume that we have some table called `foo`, which have two partitioned tables (master tables) `bar` and `baz`.
Assume that each of tables is partitioned by some range of dates. Then each one will have, ideally, partitions called, i.x.:

 - `bar_y2022m10` or `bar_2022_10`, etc
 - `bar_y2022m11` or ...
 - `baz_y2022m10` or ...
 - `baz_y2022m11` or ...

For such case, cmd for generating xo code would look, i.x., like this: 

`//go:generate go run github.com/xo/xo pgsql://$PGHOST/mailer --include-tables "bar|baz" --exclude-tables ".*20.*" --escape-table -o db/ --template-path ../../_xo_templates/ --escape-column`

We include all tables which include `bar` or `baz` names, and exclude all tables that have names corresponding to regular expression `--exclude-tables ".*20.*"`.

So, the code is only generated for the master tables.